### PR TITLE
feat: 카카오 소셜 로그인 api 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### env ###
+local.env
+.env
+*.env

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,15 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
 
+    // Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // Jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation 'com.nimbusds:nimbus-jose-jwt:9.37'
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4'
 

--- a/src/main/java/motgolla/domain/member/api/MemberController.java
+++ b/src/main/java/motgolla/domain/member/api/MemberController.java
@@ -1,0 +1,64 @@
+package motgolla.domain.member.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import motgolla.domain.member.dto.request.LoginRequest;
+import motgolla.domain.member.dto.request.SignUpRequest;
+import motgolla.domain.member.dto.response.TokenResponse;
+import motgolla.domain.member.service.MemberService;
+import motgolla.domain.member.vo.Member;
+
+@Slf4j
+@RequestMapping("/api/member")
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+	private final MemberService memberService;
+
+	@PostMapping("/develop")
+	public ResponseEntity<TokenResponse> develop(@RequestBody SignUpRequest signUpRequest) {
+		TokenResponse response = memberService.createDevelopAccount(signUpRequest);
+		return ResponseEntity.ok().body(response);
+	}
+
+	@PostMapping("/login")
+	public ResponseEntity<TokenResponse> login(@AuthenticationPrincipal Member member) {
+		TokenResponse response = memberService.login(member);
+		return ResponseEntity.ok().body(response);
+	}
+
+	@PostMapping("/sign-up")
+	public ResponseEntity<TokenResponse> signUp(@RequestBody SignUpRequest signUpRequest) {
+		TokenResponse response = memberService.signUp(signUpRequest);
+		return ResponseEntity.ok().body(response);
+	}
+
+	@PatchMapping("/resign")
+	public ResponseEntity<String> resign(@AuthenticationPrincipal Member member){
+		memberService.resign(member);
+		return ResponseEntity.ok().body("success");
+	}
+
+	@PatchMapping("/logout")
+	public ResponseEntity<String> logout(@AuthenticationPrincipal Member member){
+		memberService.logout(member);
+		return ResponseEntity.ok().body("success");
+	}
+
+	@GetMapping("/test")
+	public ResponseEntity<String> test(@AuthenticationPrincipal Member member){
+		return ResponseEntity.ok().body(member.getName());
+	}
+}

--- a/src/main/java/motgolla/domain/member/dto/request/LoginRequest.java
+++ b/src/main/java/motgolla/domain/member/dto/request/LoginRequest.java
@@ -1,0 +1,7 @@
+package motgolla.domain.member.dto.request;
+
+public record LoginRequest(
+	String idToken,
+	String oauthId
+) {
+}

--- a/src/main/java/motgolla/domain/member/dto/request/SignUpRequest.java
+++ b/src/main/java/motgolla/domain/member/dto/request/SignUpRequest.java
@@ -1,0 +1,15 @@
+package motgolla.domain.member.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SignUpRequest{
+	private Long id;
+	private String oauthId;
+	private String idToken;
+	private String name;
+	private String gender;
+	private String birthday;
+}

--- a/src/main/java/motgolla/domain/member/dto/response/TokenResponse.java
+++ b/src/main/java/motgolla/domain/member/dto/response/TokenResponse.java
@@ -1,0 +1,7 @@
+package motgolla.domain.member.dto.response;
+
+public record TokenResponse(
+	String accessToken,
+	String refreshToken
+) {
+}

--- a/src/main/java/motgolla/domain/member/enums/Example.java
+++ b/src/main/java/motgolla/domain/member/enums/Example.java
@@ -1,0 +1,4 @@
+package motgolla.domain.member.enums;
+
+public enum Example {
+}

--- a/src/main/java/motgolla/domain/member/enums/Role.java
+++ b/src/main/java/motgolla/domain/member/enums/Role.java
@@ -1,0 +1,10 @@
+package motgolla.domain.member.enums;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public enum Role {
+	ROLE_ADMIN, ROLE_USER
+}

--- a/src/main/java/motgolla/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/motgolla/domain/member/mapper/MemberMapper.java
@@ -1,0 +1,17 @@
+package motgolla.domain.member.mapper;
+
+import java.util.Optional;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import motgolla.domain.member.dto.request.SignUpRequest;
+import motgolla.domain.member.vo.Member;
+
+@Mapper
+public interface MemberMapper {
+	void insertMember(@Param("request") SignUpRequest signUpRequest);
+	void deleteMember(Member member);
+	Optional<Member> findById(Long id);
+	Optional<Member> findByOauthId(String oauthId);
+}

--- a/src/main/java/motgolla/domain/member/service/MemberService.java
+++ b/src/main/java/motgolla/domain/member/service/MemberService.java
@@ -1,0 +1,14 @@
+package motgolla.domain.member.service;
+
+import motgolla.domain.member.dto.request.LoginRequest;
+import motgolla.domain.member.dto.request.SignUpRequest;
+import motgolla.domain.member.dto.response.TokenResponse;
+import motgolla.domain.member.vo.Member;
+
+public interface MemberService {
+	TokenResponse createDevelopAccount(SignUpRequest signUpRequest);
+	TokenResponse login(Member member);
+	TokenResponse signUp(SignUpRequest signUpRequest);
+	void logout(Member member);
+	void resign(Member member);
+}

--- a/src/main/java/motgolla/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/motgolla/domain/member/service/MemberServiceImpl.java
@@ -1,0 +1,66 @@
+package motgolla.domain.member.service;
+
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import motgolla.domain.member.dto.request.LoginRequest;
+import motgolla.domain.member.dto.request.SignUpRequest;
+import motgolla.domain.member.dto.response.TokenResponse;
+import motgolla.domain.member.mapper.MemberMapper;
+import motgolla.domain.member.vo.Member;
+import motgolla.global.auth.jwt.JwtProvider;
+import motgolla.global.auth.login.OidcService;
+import motgolla.global.error.ErrorCode;
+import motgolla.global.error.exception.BusinessException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService {
+	private final MemberMapper memberMapper;
+	private final JwtProvider jwtProvider;
+	private final OidcService oidcService;
+
+	@Override
+	public TokenResponse createDevelopAccount(SignUpRequest signUpRequest) {
+		memberMapper.insertMember(signUpRequest);
+		Member member = memberMapper.findById(signUpRequest.getId()).get();
+
+		return jwtProvider.provideAccessTokenAndRefreshToken(member);
+	}
+
+	@Override
+	public TokenResponse login(Member member) {
+		return jwtProvider.provideAccessTokenAndRefreshToken(member);
+	}
+
+	@Override
+	public TokenResponse signUp(SignUpRequest signUpRequest) {
+		// 중복 검사
+		if(memberMapper.findByOauthId(signUpRequest.getOauthId()).isPresent()){
+			throw new BusinessException(ErrorCode.DUPLICATED_MEMBER);
+		}
+		Map<String, Object> claims = oidcService.verify(signUpRequest.getIdToken());
+		String oauthId = (String) claims.get("sub");
+		signUpRequest.setOauthId(oauthId);
+
+		memberMapper.insertMember(signUpRequest);
+		Long memberId = signUpRequest.getId();
+		String accessToken = jwtProvider.createAccessToken(memberId);
+		String refreshToken = jwtProvider.createRefreshToken(memberId);
+		return new TokenResponse(accessToken, refreshToken);
+	}
+
+	@Override
+	public void logout(Member member) {
+		// 토큰 만료 처리
+	}
+
+	@Override
+	public void resign(Member member) {
+		// 논리적 삭제
+	}
+}

--- a/src/main/java/motgolla/domain/member/vo/Member.java
+++ b/src/main/java/motgolla/domain/member/vo/Member.java
@@ -1,0 +1,65 @@
+package motgolla.domain.member.vo;
+
+
+import java.util.Collection;
+import java.util.List;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+
+@Getter
+@Setter
+public class Member implements UserDetails {
+	private Long id;
+	private String name;
+	private String oauthId;
+	private String profile;
+	private String birthday;
+	private String gender;
+	private String refreshToken;
+	private String createdAt;
+	private String createdBy;
+	private String updatedAt;
+	private String updatedBy;
+	private int isDeleted;
+
+    @Override
+    public String getUsername() {
+        return String.valueOf(id);
+    }
+
+    @Override
+    public String getPassword() {
+        // Placeholder: implement as needed
+        return null;
+    }
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+	}
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/motgolla/global/auth/jwt/JwtAuthenticationExceptionHandler.java
+++ b/src/main/java/motgolla/global/auth/jwt/JwtAuthenticationExceptionHandler.java
@@ -1,0 +1,43 @@
+package motgolla.global.auth.jwt;
+
+import java.io.IOException;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import motgolla.global.error.ErrorResponse;
+import motgolla.global.error.exception.InvalidTokenException;
+
+@Slf4j
+public class JwtAuthenticationExceptionHandler extends OncePerRequestFilter {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (InvalidTokenException e) {
+            log.error("InvalidTokenException: {}", e.getMessage());
+            setErrorResponse(response, e);
+        }
+    }
+
+    private void setErrorResponse(HttpServletResponse response, InvalidTokenException e){
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(e.getErrorCode().getStatus());
+        ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode());
+        try{
+            response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+        }catch (IOException ex){
+            ex.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/motgolla/global/auth/jwt/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/motgolla/global/auth/jwt/JwtAuthenticationProcessingFilter.java
@@ -1,0 +1,161 @@
+package motgolla.global.auth.jwt;
+
+import static motgolla.global.config.SecurityConfig.*;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import motgolla.domain.member.mapper.MemberMapper;
+import motgolla.domain.member.vo.Member;
+import motgolla.global.error.ErrorCode;
+import motgolla.global.error.exception.InvalidTokenException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
+
+    /**
+     * JWT 인증 필터 - 로그인 이외의 요청을 처리
+     * 기본적으로 사용자는 요청 헤더에 AccessToken만 담아서 요청
+     * AccessToken 만료 시에만 RefreshToken을 요청 헤더에 넣어 요청
+     * 1. AccessToken이 유효한 경우 -> 인증 성공
+     * 2. RefreshToken이 없고, AccessToken이 없거나 유효하지 않은 경우 -> 인증 실패 (401)
+     * 3. 유효한 refresh token -> access, refresh 모두 재발급(RTR 방식)
+     * 4. 유효하지 않은 refresh token -> 인증 실패 (401)
+     */
+
+    private static final String REISSUE_TOKEN_URL = "/api/member/reissue";
+    private static final Set<String> NO_CHECK_URL = new HashSet<>(Arrays.asList(
+        LOGIN_URL,
+        SIGNUP_URL,
+        STATIC_RESOURCE,
+        "/swagger-ui/index.html",
+        "/swagger-ui.html",
+        "/v3/api-docs",
+        "/v3/api-docs/**",
+        "/swagger-ui/**",
+        "/webjars/**",
+        URL_PREFIX + "/member/develop"
+    ));
+    private final JwtProvider jwtProvider;
+    private final MemberMapper memberMapper;
+    private final GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
+    private final AntPathMatcher antPathMatcher = new AntPathMatcher();
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException{
+        // NO_CHECK_URL에 해당하는 경우 그냥 통과
+        for (String path : NO_CHECK_URL) {
+            if (antPathMatcher.match(path, request.getRequestURI())) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+        }
+
+        if(request.getRequestURI().equals(REISSUE_TOKEN_URL)) {
+            reissueToken(request, response);
+        }
+        else{
+            checkAccessTokenAndAuthentication(request, response, filterChain);
+        }
+    }
+
+    private void reissueToken(HttpServletRequest request, HttpServletResponse response){
+        log.info("refresh token 유효성 검증");
+        String refreshToken = jwtProvider.extractRefreshToken(request)
+            .orElseThrow(() -> new InvalidTokenException(ErrorCode.INVALID_REFRESH_TOKEN));
+
+        if(jwtProvider.isTokenValid(refreshToken)){
+            Long memberId = jwtProvider.extractMemberId(refreshToken)
+                .orElseThrow(() -> new InvalidTokenException(ErrorCode.INVALID_REFRESH_TOKEN));
+
+            Member member = memberMapper.findById(memberId)
+                .orElseThrow(() -> new InvalidTokenException(ErrorCode.INVALID_REFRESH_TOKEN));
+
+            jwtProvider.provideAccessToken(response, member);
+        }
+        else{
+            throw new InvalidTokenException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+    }
+
+
+    // access token 검사 및 인증 처리
+    // request에서 extractAccessToken()으로 액세스 토큰 추출 후, isTokenValid()로 유효한 토큰인지 검증
+    // 유효한 토큰이면, 액세스 토큰에서 extractUsername으로 username을 추출한 후 findByUsername()로 Member 객체 반환
+    // 그 유저 객체를 saveAuthentication()으로 인증 처리하여
+    // 인증 허가 처리된 객체를 SecurityContextHolder에 담은 후 다음 필터로 넘김
+    private void checkAccessTokenAndAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain){
+        log.info("checkAccessTokenAndAuthentication 진입");
+        String accessToken = jwtProvider.extractAccessToken(request)
+            .orElseThrow(() -> new InvalidTokenException(ErrorCode.INVALID_ACCESS_TOKEN));
+
+        if(jwtProvider.isTokenValid(accessToken)){
+            jwtProvider.extractMemberId(accessToken)
+                .flatMap(memberMapper::findById)
+                .ifPresentOrElse(
+                    member -> {
+                        log.info("인증 성공");
+                        saveAuthentication(member); // 인증 허가 처리
+                        try {
+                            filterChain.doFilter(request, response);
+                        } catch (IOException | ServletException e) {
+                            throw new RuntimeException(e);
+                        }
+                    },
+                    () -> {
+                        throw new InvalidTokenException(ErrorCode.INVALID_ACCESS_TOKEN);
+                    }
+                );
+        }
+        else{
+            throw new InvalidTokenException(ErrorCode.INVALID_ACCESS_TOKEN);
+        }
+
+    }
+
+    /**
+     * 인증 허가 처리
+     * SecurityContextHolder.getContext()로 SecurityContext를 꺼낸 후,
+     * setAuthentication()을 이용하여 위에서 만든 Authentication 객체에 대한 인증 허가 처리
+     */
+    private void saveAuthentication(Member member) {
+        UserDetails userDetails = member;
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                        userDetails,
+                        userDetails.getPassword(),
+                        authoritiesMapper.mapAuthorities(userDetails.getAuthorities())
+        );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+
+    // 요청의 refresh token이 db에 저장된 refresh token과 일치하는지 검사
+    // private boolean isRefreshTokenValidInDatabase(String refreshToken){
+    //     log.info("isRefreshTokenValidInDatabase 진입");
+    //     boolean result = false;
+    //     if (memberRepository.findByRefreshToken(refreshToken).isPresent()) {
+    //         return true;
+    //     }
+    //     return result;
+    // }
+
+}

--- a/src/main/java/motgolla/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/motgolla/global/auth/jwt/JwtProvider.java
@@ -1,0 +1,164 @@
+package motgolla.global.auth.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import javax.crypto.SecretKey;
+
+import java.util.Date;
+import java.util.Optional;
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import motgolla.domain.member.dto.response.TokenResponse;
+import motgolla.domain.member.mapper.MemberMapper;
+import motgolla.domain.member.vo.Member;
+
+@Slf4j
+@Getter
+@Service
+@RequiredArgsConstructor
+public class JwtProvider{
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.access.expiration}")
+    private Long accessTokenExpirationPeriod;
+
+    @Value("${jwt.refresh.expiration}")
+    private Long refreshTokenExpirationPeriod;
+
+    private static final String ACCESS_HEADER = "Authorization";
+    private static final String REFRESH_HEADER = "Authorization-Refresh";
+
+
+    private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
+    private static final String REFRESH_TOKEN_SUBJECT = "RefreshToken";
+    private static final String OAUTH_ID_CLAIM = "OAuthId";
+    private static final String BEARER = "Bearer ";
+    private static final String ID_CLAIM = "id";
+
+    private final MemberMapper memberMapper;
+
+    /**
+     * access token 생성
+     */
+    public String createAccessToken(Long id) {
+        Date now = new Date();
+        SecretKey key = Keys.hmacShaKeyFor(secret.getBytes());
+        return Jwts.builder()
+            .setSubject(ACCESS_TOKEN_SUBJECT)
+            .claim(ID_CLAIM, id)
+            .setIssuedAt(now)
+            .setExpiration(new Date(now.getTime() + accessTokenExpirationPeriod))
+            .signWith(key, SignatureAlgorithm.HS512)
+            .compact();
+    }
+
+    /**
+     * refresh token 생성
+     */
+    public String createRefreshToken(Long id) {
+        Date now = new Date();
+        SecretKey key = Keys.hmacShaKeyFor(secret.getBytes());
+        return Jwts.builder()
+                .setSubject(REFRESH_TOKEN_SUBJECT)
+                .claim(ID_CLAIM, id)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + refreshTokenExpirationPeriod))
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    /**
+     * 헤더에서 access token 추출
+     */
+    public Optional<String> extractAccessToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(ACCESS_HEADER))
+            .filter(accessToken -> accessToken.startsWith(BEARER))
+            .map(accessToken -> accessToken.replace(BEARER, ""));
+    }
+
+    /**
+     * 헤더에서 refresh token 추출
+     */
+    public Optional<String> extractRefreshToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(REFRESH_HEADER))
+            .filter(refreshToken -> refreshToken.startsWith(BEARER))
+            .map(refreshToken -> refreshToken.replace(BEARER, ""));
+    }
+
+    /**
+     * access token에서 username 추출
+     * access token이 유효하면 username 반환, 유효하지 않으면 Optional.empty 반환
+     */
+    public Optional<Long> extractMemberId(String accessToken) {
+        try {
+            SecretKey key = Keys.hmacShaKeyFor(secret.getBytes());
+            Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(accessToken)
+                .getBody();
+            return Optional.ofNullable(claims.get(ID_CLAIM, Long.class));
+        } catch (Exception e) {
+            log.error("액세스 토큰이 유효하지 않습니다.");
+            return Optional.empty();
+        }
+    }
+
+    public void provideAccessToken(HttpServletResponse response, Member member) {
+        String accessToken = createAccessToken(member.getId());
+        try {
+            Map<String, String> tokenMap = Map.of("accessToken", accessToken);
+            writeResponse(response, tokenMap);
+        } catch (IOException e) {
+            throw new RuntimeException("응답 JSON 쓰기 실패", e);
+        }
+    }
+
+    public TokenResponse provideAccessTokenAndRefreshToken(Member member) {
+        String accessToken = createAccessToken(member.getId());
+        String refreshToken = createRefreshToken(member.getId());
+
+        return new TokenResponse(accessToken, refreshToken);
+    }
+
+
+    private void writeResponse(HttpServletResponse response, Map<String, String> tokenMap) throws IOException {
+        String json = new ObjectMapper().writeValueAsString(tokenMap);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(json);
+        response.setStatus(HttpServletResponse.SC_OK);
+    }
+
+
+    /**
+     * 토튼 유효성 검사
+     */
+    public boolean isTokenValid(String token){
+        try {
+            SecretKey key = Keys.hmacShaKeyFor(secret.getBytes());
+            Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+}

--- a/src/main/java/motgolla/global/auth/login/CustomAuthenticationProvider.java
+++ b/src/main/java/motgolla/global/auth/login/CustomAuthenticationProvider.java
@@ -1,0 +1,42 @@
+package motgolla.global.auth.login;
+
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class CustomAuthenticationProvider implements AuthenticationProvider {
+
+    private final UserDetailsService userDetailsService;
+    private final GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
+
+    /**
+     * 요청의 username과 db에 저장된 username을 비교하여 일치하면 인증 성공
+     * 인증에 성공하면, UserDetail 정보를 기반으로 UsernamePasswordAuthenticationToken 객체를 생성하여 반환한다.
+     */
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        String oauthId = authentication.getPrincipal().toString(); // 평문의 oauthId
+        UserDetails userDetails = userDetailsService.loadUserByUsername(oauthId);
+        return new UsernamePasswordAuthenticationToken(
+                userDetails,
+                userDetails.getPassword(),
+                authoritiesMapper.mapAuthorities(userDetails.getAuthorities())
+        );
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/src/main/java/motgolla/global/auth/login/CustomJsonUsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/motgolla/global/auth/login/CustomJsonUsernamePasswordAuthenticationFilter.java
@@ -1,0 +1,74 @@
+package motgolla.global.auth.login;
+
+import static motgolla.global.config.SecurityConfig.*;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.util.StreamUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * "/login" 요청 왔을 때 JSON 값을 매핑 처리하는 필터
+ * 스프링 시큐리티의 폼 기반의 UsernamePasswordAuthenticationFilter를 커스텀하여
+ * 폼 로그인 대신 Json Login만 처리하도록 설정함
+ */
+@Slf4j
+public class CustomJsonUsernamePasswordAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
+
+    private static final String HTTP_METHOD = "POST";
+    private static final String CONTENT_TYPE = "application/json";
+    private static final String OAuth_ID_KEY = "oauthId";
+    private static final AntPathRequestMatcher DEFAULT_LOGIN_PATH_REQUEST_MATCHER =
+            new AntPathRequestMatcher(LOGIN_URL, HTTP_METHOD); // 로그인 요청
+
+    private final ObjectMapper objectMapper;
+
+    public CustomJsonUsernamePasswordAuthenticationFilter(ObjectMapper objectMapper) {
+        super(DEFAULT_LOGIN_PATH_REQUEST_MATCHER);
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * 인증 처리 메소드
+     *
+     * UsernamePasswordAuthenticationFilter와 동일하게 UsernamePasswordAuthenticationToken 사용
+     * StreamUtils를 통해 request에서 messageBody(JSON) 반환
+     *
+     * messageBody를 objectMapper.readValue()로 Map으로 변환
+     * Map의 Key로 username 추출 후
+     * CustomAuthenticationToken의 파라미터 principal, credentials에 대입
+     *
+     * AbstractAuthenticationProcessingFilter(부모)의 getAuthenticationManager()로 AuthenticationManager 객체를 반환 받은 후
+     * authenticate()의 파라미터로 CustomAuthenticationToken 객체를 넣고 인증 처리
+     * (여기서 AuthenticationManager 객체는 ProviderManager -> SecurityConfig에서 설정)
+     */
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException, IOException, ServletException {
+        if(request.getContentType() == null || !request.getContentType().equals(CONTENT_TYPE)) {
+            throw new AuthenticationServiceException("Authentication Content-Type not supported: " + request.getContentType());
+        }
+
+        String messageBody = StreamUtils.copyToString(request.getInputStream(), StandardCharsets.UTF_8);
+        Map<String, String> loginDataMap = objectMapper.readValue(messageBody, Map.class);
+        String oauthId = loginDataMap.get(OAuth_ID_KEY);
+
+        UsernamePasswordAuthenticationToken authRequest = new UsernamePasswordAuthenticationToken(oauthId, "");
+
+        return this.getAuthenticationManager().authenticate(authRequest);
+    }
+}

--- a/src/main/java/motgolla/global/auth/login/LoginFailureHandler.java
+++ b/src/main/java/motgolla/global/auth/login/LoginFailureHandler.java
@@ -1,0 +1,39 @@
+package motgolla.global.auth.login;
+
+
+import java.io.IOException;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import motgolla.global.error.ErrorCode;
+import motgolla.global.error.ErrorResponse;
+
+@Slf4j
+@RequiredArgsConstructor
+public class LoginFailureHandler implements AuthenticationFailureHandler {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.LOGIN_FAILED);
+        ResponseEntity<ErrorResponse> entity = ResponseEntity
+                .status(HttpServletResponse.SC_UNAUTHORIZED)
+                .body(errorResponse);
+
+        response.setStatus(entity.getStatusCode().value());
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType("application/json");
+        response.getWriter().write(objectMapper.writeValueAsString(entity.getBody()));
+        log.info(exception.getMessage());
+    }
+
+}

--- a/src/main/java/motgolla/global/auth/login/LoginService.java
+++ b/src/main/java/motgolla/global/auth/login/LoginService.java
@@ -1,0 +1,44 @@
+package motgolla.global.auth.login;
+
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import motgolla.domain.member.mapper.MemberMapper;
+import motgolla.domain.member.vo.Member;
+import motgolla.global.util.HashUtil;
+
+/**
+ *    파라미터로 username으로 DB에서 일치하는 Member를 찾고,
+ *    해당 회원의 username과 Role을 담아 UserDetails의 User 객체를 생성한다.
+ */
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LoginService implements UserDetailsService {
+
+    private final MemberMapper memberMapper;
+    private final HashUtil hashUtil;
+
+    /**
+     * 파라미터 socialId를 해싱 처리한 후 db에서 일치하는 사용자를 조회한다.
+     * 비밀번호는 인증 절차에 필요하지 않으므로 난수로 만든 다음 UserDetail 객체로 넘긴다.
+     */
+
+    @Override
+    public UserDetails loadUserByUsername(String oauthId) throws UsernameNotFoundException {
+        log.info("loadUserByUsername 진입");
+        String hashedOauthId = hashUtil.hash(oauthId);
+         Member member = memberMapper.findByOauthId(hashedOauthId)
+             .filter(m -> m.getIsDeleted() == 0)
+                .orElseThrow(() -> new UsernameNotFoundException("로그인에 실패했습니다."));
+
+        return member;
+    }
+
+}

--- a/src/main/java/motgolla/global/auth/login/OidcService.java
+++ b/src/main/java/motgolla/global/auth/login/OidcService.java
@@ -1,0 +1,54 @@
+package motgolla.global.auth.login;
+
+import com.nimbusds.jose.jwk.source.RemoteJWKSet;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.*;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.jwt.proc.*;
+
+import java.net.URL;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import motgolla.global.error.ErrorCode;
+import motgolla.global.error.exception.BusinessException;
+
+@Service
+public class OidcService {
+
+	private static final String KAKAO_JWKS_URI = "https://kauth.kakao.com/.well-known/jwks.json";
+	private static final String KAKAO_ISSUER = "https://kauth.kakao.com";
+
+	@Value("${kakao.rest-api-key}")
+	private String CLIENT_ID; // OIDC client_id
+
+	public Map<String, Object> verify(String idToken) {
+		try {
+			SignedJWT signedJWT = SignedJWT.parse(idToken);
+
+			// JWK를 이용한 서명 검증
+			JWKSource<SecurityContext> keySource = new RemoteJWKSet<>(new URL(KAKAO_JWKS_URI));
+			ConfigurableJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<>();
+			JWSKeySelector<SecurityContext> keySelector =
+				new JWSVerificationKeySelector<>(signedJWT.getHeader().getAlgorithm(), keySource);
+
+			jwtProcessor.setJWSKeySelector(keySelector);
+
+			// 검증 후 claims 추출
+			JWTClaimsSet claimsSet = jwtProcessor.process(signedJWT, null);
+
+			// issuer, audience 검증 (카카오 기준)
+			if (!claimsSet.getIssuer().equals(KAKAO_ISSUER) || !claimsSet.getAudience().contains(CLIENT_ID)) {
+				throw new BusinessException(ErrorCode.INVALID_ID_TOKEN);
+			}
+
+			return claimsSet.getClaims();
+
+		} catch (Exception e) {
+			throw new RuntimeException("idToken 검증 실패", e);
+		}
+	}
+}

--- a/src/main/java/motgolla/global/config/SecurityConfig.java
+++ b/src/main/java/motgolla/global/config/SecurityConfig.java
@@ -1,0 +1,118 @@
+package motgolla.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import motgolla.domain.member.mapper.MemberMapper;
+import motgolla.global.auth.jwt.JwtAuthenticationExceptionHandler;
+import motgolla.global.auth.jwt.JwtAuthenticationProcessingFilter;
+import motgolla.global.auth.jwt.JwtProvider;
+import motgolla.global.auth.login.CustomAuthenticationProvider;
+import motgolla.global.auth.login.CustomJsonUsernamePasswordAuthenticationFilter;
+import motgolla.global.auth.login.LoginFailureHandler;
+import motgolla.global.auth.login.LoginService;
+
+@Slf4j
+@RequiredArgsConstructor
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+
+    public static final String URL_PREFIX = "/api";
+    public static final String LOGIN_URL = URL_PREFIX + "/member/login";
+    public static final String SIGNUP_URL = URL_PREFIX + "/member/sign-up";
+    public static final String STATIC_RESOURCE = "/css/**";
+
+    private final LoginService loginService;
+    private final JwtProvider jwtProvider;
+    private final ObjectMapper objectMapper;
+    private final MemberMapper memberMapper;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable()) // CSRF 보호 비활성화
+                .formLogin(form -> form.disable()) // 기본 폼 로그인 비활성화
+                .httpBasic(basic -> basic.disable()) // HTTP Basic 인증 비활성화
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 정책을 STATELESS로 설정
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(
+                                LOGIN_URL,
+                                SIGNUP_URL,
+                                STATIC_RESOURCE,
+                                URL_PREFIX + "/member/develop",
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-resources/**",
+                                "/webjars/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()); // 나머지 모든 경로 인증 필요
+
+        // LogoutFilter -> JwtAuthenticationExceptionHandler -> JwtAuthenticationProcessingFilter -> CustomJsonUsernamePasswordAuthenticationFilter
+        http.addFilterAfter(customJsonUsernamePasswordAuthenticationFilter(), LogoutFilter.class);
+        http.addFilterBefore(jwtAuthenticationProcessingFilter(), CustomJsonUsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(jwtAuthenticationExceptionHandler(), JwtAuthenticationProcessingFilter.class);
+        //http.addFilterBefore(new LogginFilter(), LogoutFilter.class);
+        return http.build();
+    }
+
+    /**
+     * AuthenticationManager 등록
+     * 커스텀한 CustomAuthenticationProvider 사용
+     * UserDetailsService는 커스텀 LoginService로 등록
+     */
+    @Bean
+    public AuthenticationManager authenticationManager() {
+        return new ProviderManager(customAuthenticationProvider());
+    }
+
+    @Bean
+    public CustomAuthenticationProvider customAuthenticationProvider() {
+        return new CustomAuthenticationProvider(loginService);
+    }
+
+    /**
+     * 로그인 실패 시 호출되는 LoginFailureHandler 빈 등록
+     */
+    @Bean
+    public LoginFailureHandler loginFailureHandler() {
+        return new LoginFailureHandler();
+    }
+
+    /**
+     * CustomJsonUsernamePasswordAuthenticationFilter 빈 등록
+     * 커스텀 필터를 사용하기 위해 만든 커스텀 필터를 Bean으로 등록
+     * setAuthenticationManager(authenticationManager())로 위에서 등록한 AuthenticationManager(ProviderManager) 설정
+     * 로그인 성공 시 호출할 handler, 실패 시 호출할 handler로 위에서 등록한 handler 설정
+     */
+    @Bean
+    public CustomJsonUsernamePasswordAuthenticationFilter customJsonUsernamePasswordAuthenticationFilter() {
+        CustomJsonUsernamePasswordAuthenticationFilter customJsonUsernamePasswordLoginFilter
+                = new CustomJsonUsernamePasswordAuthenticationFilter(objectMapper);
+        customJsonUsernamePasswordLoginFilter.setAuthenticationManager(authenticationManager());
+        customJsonUsernamePasswordLoginFilter.setAuthenticationFailureHandler(loginFailureHandler());
+        return customJsonUsernamePasswordLoginFilter;
+    }
+
+    @Bean
+    public JwtAuthenticationProcessingFilter jwtAuthenticationProcessingFilter() {
+        return new JwtAuthenticationProcessingFilter(jwtProvider, memberMapper);
+    }
+
+    @Bean
+    public JwtAuthenticationExceptionHandler jwtAuthenticationExceptionHandler() {
+        return new JwtAuthenticationExceptionHandler();
+    }
+
+}

--- a/src/main/java/motgolla/global/error/ErrorCode.java
+++ b/src/main/java/motgolla/global/error/ErrorCode.java
@@ -8,7 +8,18 @@ public enum ErrorCode {
     /* COMMON ERROR */
     INTERNAL_SERVER_ERROR(500, "COMMON001", "Internal Server Error"),
     INVALID_INPUT_VALUE(400, "COMMON002", "Invalid Input Value"),
-    ENTITY_NOT_FOUND(400, "COMMON003", "Entity Not Found");
+    ENTITY_NOT_FOUND(400, "COMMON003", "Entity Not Found"),
+
+    /* AUTH ERROR */
+    INVALID_ACCESS_TOKEN(401, "AUTH001", "Invalid Access Token"),
+    INVALID_REFRESH_TOKEN(401, "AUTH002", "Invalid Refresh Token"),
+    LOGIN_FAILED(400, "AUTH003", "Login Failed"),
+    INVALID_ID_TOKEN(400, "AUTH004", "Invalid ID Token"),
+
+    /* MEMBER ERROR */
+    MEMBER_NOT_FOUND(404, "MEMBER001", "Member Not Found"),
+    DUPLICATED_MEMBER(400, "MEMBER002", "Duplicated Member");
+
 
     private final int status;
     private final String code;

--- a/src/main/java/motgolla/global/error/exception/InvalidTokenException.java
+++ b/src/main/java/motgolla/global/error/exception/InvalidTokenException.java
@@ -1,0 +1,22 @@
+package motgolla.global.error.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+import lombok.Getter;
+import motgolla.global.error.ErrorCode;
+
+@Getter
+public class InvalidTokenException extends AuthenticationException {
+    private final ErrorCode errorCode;
+
+    public InvalidTokenException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public InvalidTokenException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/motgolla/global/util/HashUtil.java
+++ b/src/main/java/motgolla/global/util/HashUtil.java
@@ -1,0 +1,39 @@
+package motgolla.global.util;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HashUtil {
+
+    public String hash(String input) {
+        try {
+            // MessageDigest 인스턴스를 SHA-256 알고리즘으로 초기화
+            MessageDigest instance = MessageDigest.getInstance("SHA-256");
+
+            // 입력 문자열을 바이트 배열로 변환 후 해싱하여 바이트 배열로 반환
+            byte[] hashBytes = instance.digest(input.getBytes());
+
+            // 해시 결과(바이트 배열)를 16진수 문자열로 변환하여 반환하기 위한 StringBuilder
+            StringBuilder sb = new StringBuilder();
+            for (byte b : hashBytes) {
+                // 각 바이트 값을 2자리 16진수로 변환하여 StringBuilder에 추가
+                sb.append(String.format("%02x", b));
+            }
+            // 최종적으로 해시된 문자열을 반환
+            return sb.toString().toUpperCase();
+
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 알고리즘이 지원되지 않는 경우 예외 처리
+            throw new RuntimeException("SHA-256 Algorithm not found", e);
+        }
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,9 +9,19 @@ server:
   port: 8080
 
 mybatis:
-  mapper-locations: classpath:mapper/**/*.xml
+  mapper-locations: classpath:mapper/*.xml
   configuration:
     map-underscore-to-camel-case: true
 
 swagger:
   server-url: http://localhost:8080
+
+jwt:
+  secret: ${JWT_SECRET}
+  access:
+    expiration: ${JWT_ACCESS_EXPIRATION}
+  refresh:
+    expiration: ${JWT_REFRESH_EXPIRATION}
+
+kakao:
+  rest-api-key: ${KAKAO_REST_API_KEY}

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="motgolla.domain.member.mapper.MemberMapper">
+    <!-- 회원 저장 -->
+    <insert id="insertMember">
+        <selectKey keyProperty="request.id" resultType="long" order="BEFORE">
+            SELECT MEMBER_SEQ.NEXTVAL AS id FROM dual
+        </selectKey>
+        INSERT INTO MEMBER (
+            ID,
+            NAME,
+            OAUTH_ID,
+            BIRTHDAY,
+            GENDER,
+            CREATED_AT,
+            UPDATED_AT
+        ) VALUES (
+            #{request.id},
+            #{request.name},
+            #{request.oauthId},
+            #{request.birthday},
+            #{request.gender},
+            SYSDATE,
+            SYSDATE
+        )
+    </insert>
+
+    <!-- ID로 회원 조회 -->
+    <select id="findById" resultType="motgolla.domain.member.vo.Member" parameterType="long">
+        SELECT
+        ID,
+        NAME,
+        PROFILE,
+        OAUTH_ID,
+        BIRTHDAY,
+        GENDER,
+        CREATED_AT,
+        CREATED_BY,
+        UPDATED_AT,
+        UPDATED_BY,
+        ISDELETED
+        FROM MEMBER
+        WHERE ID = #{id}
+    </select>
+
+    <!-- OAUTH_ID로 회원 조회 -->
+    <select id="findByOauthId" resultType="motgolla.domain.member.vo.Member" parameterType="string">
+        SELECT
+        ID,
+        NAME,
+        PROFILE,
+        OAUTH_ID,
+        BIRTHDAY,
+        GENDER,
+        CREATED_AT,
+        CREATED_BY,
+        UPDATED_AT,
+        UPDATED_BY,
+        ISDELETED
+        FROM MEMBER
+        WHERE OAUTH_ID = #{oauthId}
+    </select>
+</mapper>


### PR DESCRIPTION
#️⃣ Issue Number
#6 

📝 요약(Summary)
카카오 소셜 로그인 API 개발, 시큐리티 필터 및 JWT 도입

🛠️ PR 유형
 새로운 기능 추가

💬 공유사항 to 리뷰어

1. 스프링 시큐리티 필터단에서 모두 로그인 작업을 처리함
2. 개발용 회원가입 api 추가했습니다. 편하게 사용해주세요!
3. JWT 발급 패턴 구현
4. AccessToken 요청 헤더로 요청
5. 유효할 시 → 통과
6. 만료될 시 → 401 에러
7. 만료 응답을 받은 경우 RefreshToken을 다시 보냄
8. 유효할 시 → accessToken 및 refreshToken 재발급 후 다시 요청
9. 만료될 시 → 401 에러, 자동 로그아웃 처리
10. 아직 로그아웃, 회원탈퇴 API는 구현하지 않음.

✅ PR Checklist
 커밋 메시지 컨벤션에 맞게 작성했습니다.
