### PR TITLE
fix: 회원가입 및 로그인 오류 해결

### DIFF
--- a/src/main/java/motgolla/domain/member/api/MemberController.java
+++ b/src/main/java/motgolla/domain/member/api/MemberController.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import motgolla.domain.member.dto.request.LoginRequest;
 import motgolla.domain.member.dto.request.SignUpRequest;
+import motgolla.domain.member.dto.response.MemberInfoResponse;
 import motgolla.domain.member.dto.response.TokenResponse;
 import motgolla.domain.member.service.MemberService;
 import motgolla.domain.member.vo.Member;
@@ -55,6 +56,11 @@ public class MemberController {
 	public ResponseEntity<String> logout(@AuthenticationPrincipal Member member){
 		memberService.logout(member);
 		return ResponseEntity.ok().body("success");
+	}
+
+	@GetMapping()
+	public ResponseEntity<MemberInfoResponse> getMemberInfo(@AuthenticationPrincipal Member member){
+		return ResponseEntity.ok().body(member.toDto());
 	}
 
 	@GetMapping("/test")

--- a/src/main/java/motgolla/domain/member/dto/response/MemberInfoResponse.java
+++ b/src/main/java/motgolla/domain/member/dto/response/MemberInfoResponse.java
@@ -1,0 +1,12 @@
+package motgolla.domain.member.dto.response;
+
+public record MemberInfoResponse(
+	Long id,
+	String name,
+	String birthday,
+	String gender,
+	String profile,
+	String createdAt
+) {
+
+}

--- a/src/main/java/motgolla/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/motgolla/domain/member/mapper/MemberMapper.java
@@ -11,7 +11,7 @@ import motgolla.domain.member.vo.Member;
 @Mapper
 public interface MemberMapper {
 	void insertMember(@Param("request") SignUpRequest signUpRequest);
-	void deleteMember(Member member);
+	void updateIsDeleted(Long id);
 	Optional<Member> findById(Long id);
 	Optional<Member> findByOauthId(String oauthId);
 }

--- a/src/main/java/motgolla/domain/member/service/MemberService.java
+++ b/src/main/java/motgolla/domain/member/service/MemberService.java
@@ -2,6 +2,7 @@ package motgolla.domain.member.service;
 
 import motgolla.domain.member.dto.request.LoginRequest;
 import motgolla.domain.member.dto.request.SignUpRequest;
+import motgolla.domain.member.dto.response.MemberInfoResponse;
 import motgolla.domain.member.dto.response.TokenResponse;
 import motgolla.domain.member.vo.Member;
 

--- a/src/main/java/motgolla/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/motgolla/domain/member/service/MemberServiceImpl.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import motgolla.domain.member.dto.request.LoginRequest;
 import motgolla.domain.member.dto.request.SignUpRequest;
+import motgolla.domain.member.dto.response.MemberInfoResponse;
 import motgolla.domain.member.dto.response.TokenResponse;
 import motgolla.domain.member.mapper.MemberMapper;
 import motgolla.domain.member.vo.Member;
@@ -15,6 +16,7 @@ import motgolla.global.auth.jwt.JwtProvider;
 import motgolla.global.auth.login.OidcService;
 import motgolla.global.error.ErrorCode;
 import motgolla.global.error.exception.BusinessException;
+import motgolla.global.util.HashUtil;
 
 @Slf4j
 @Service
@@ -23,9 +25,11 @@ public class MemberServiceImpl implements MemberService {
 	private final MemberMapper memberMapper;
 	private final JwtProvider jwtProvider;
 	private final OidcService oidcService;
+	private final HashUtil hashUtil;
 
 	@Override
 	public TokenResponse createDevelopAccount(SignUpRequest signUpRequest) {
+		signUpRequest.setOauthId(hashUtil.hash(signUpRequest.getOauthId()));
 		memberMapper.insertMember(signUpRequest);
 		Member member = memberMapper.findById(signUpRequest.getId()).get();
 
@@ -62,5 +66,6 @@ public class MemberServiceImpl implements MemberService {
 	@Override
 	public void resign(Member member) {
 		// 논리적 삭제
+		memberMapper.updateIsDeleted(member.getId());
 	}
 }

--- a/src/main/java/motgolla/domain/member/vo/Member.java
+++ b/src/main/java/motgolla/domain/member/vo/Member.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 import lombok.Getter;
 import lombok.Setter;
+import motgolla.domain.member.dto.response.MemberInfoResponse;
+
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -62,4 +64,8 @@ public class Member implements UserDetails {
     public boolean isEnabled() {
         return true;
     }
+
+	public MemberInfoResponse toDto(){
+		return new MemberInfoResponse(id, name, birthday, gender, profile, createdAt);
+	}
 }

--- a/src/main/java/motgolla/global/auth/login/CustomJsonUsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/motgolla/global/auth/login/CustomJsonUsernamePasswordAuthenticationFilter.java
@@ -59,7 +59,7 @@ public class CustomJsonUsernamePasswordAuthenticationFilter extends AbstractAuth
      */
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException, IOException, ServletException {
-        if(request.getContentType() == null || !request.getContentType().equals(CONTENT_TYPE)) {
+        if(request.getContentType() == null || !request.getContentType().startsWith(CONTENT_TYPE)) {
             throw new AuthenticationServiceException("Authentication Content-Type not supported: " + request.getContentType());
         }
 

--- a/src/main/java/motgolla/global/auth/login/LoginService.java
+++ b/src/main/java/motgolla/global/auth/login/LoginService.java
@@ -33,12 +33,11 @@ public class LoginService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String oauthId) throws UsernameNotFoundException {
         log.info("loadUserByUsername 진입");
+        log.info("oauthId: {}", oauthId);
         String hashedOauthId = hashUtil.hash(oauthId);
-         Member member = memberMapper.findByOauthId(hashedOauthId)
+         return memberMapper.findByOauthId(hashedOauthId)
              .filter(m -> m.getIsDeleted() == 0)
                 .orElseThrow(() -> new UsernameNotFoundException("로그인에 실패했습니다."));
-
-        return member;
     }
 
 }

--- a/src/main/java/motgolla/global/auth/login/OidcService.java
+++ b/src/main/java/motgolla/global/auth/login/OidcService.java
@@ -24,7 +24,7 @@ public class OidcService {
 	private static final String KAKAO_JWKS_URI = "https://kauth.kakao.com/.well-known/jwks.json";
 	private static final String KAKAO_ISSUER = "https://kauth.kakao.com";
 
-	@Value("${kakao.rest-api-key}")
+	@Value("${kakao.api-key}")
 	private String CLIENT_ID; // OIDC client_id
 
 	public Map<String, Object> verify(String idToken) {

--- a/src/main/java/motgolla/global/auth/login/OidcService.java
+++ b/src/main/java/motgolla/global/auth/login/OidcService.java
@@ -13,9 +13,11 @@ import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import lombok.extern.slf4j.Slf4j;
 import motgolla.global.error.ErrorCode;
 import motgolla.global.error.exception.BusinessException;
 
+@Slf4j
 @Service
 public class OidcService {
 
@@ -48,6 +50,7 @@ public class OidcService {
 			return claimsSet.getClaims();
 
 		} catch (Exception e) {
+			log.error(e.getMessage(), e);
 			throw new RuntimeException("idToken 검증 실패", e);
 		}
 	}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,7 +29,7 @@ jwt:
     expiration: ${JWT_REFRESH_EXPIRATION}
 
 kakao:
-  rest-api-key: ${KAKAO_REST_API_KEY}
+  api-key: ${KAKAO_API_KEY}
 
 cloud:
   aws:

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -63,4 +63,8 @@
         FROM MEMBER
         WHERE OAUTH_ID = #{oauthId}
     </select>
+
+    <update id="updateIsDeleted" parameterType="long">
+        UPDATE MEMBER SET ISDELETED = 1 WHERE ID = #{id}
+    </update>
 </mapper>


### PR DESCRIPTION
## #️⃣ Issue Number

#6 

## 📝 요약(Summary)

회원 가입 시 oauthId 해쉬 처리
헤더에 요청 시 content type 에러 해결

## 🛠️ PR 유형
- [x] 버그 수정

## 💬 공유사항 to 리뷰어

1. 회원 가입 시 oauthId 해쉬 처리
- 실수로 hash처리 안하고 저장했기 때문에 해쉬 처리 후 비교 시 해쉬 값으로 비교할 수 있도록 처리
2. 헤더에 요청 시 content type 에러 해결
- 'application/json'으로 시작한다면 통과할 수 있도록 변경
