### PR TITLE
fix: 로그인 시 재가입 요청 추가, logout http 메서드 수정

### DIFF
--- a/src/main/java/motgolla/domain/member/api/MemberController.java
+++ b/src/main/java/motgolla/domain/member/api/MemberController.java
@@ -56,7 +56,7 @@ public class MemberController {
 		return ResponseEntity.ok().body("success");
 	}
 
-	@PatchMapping("/logout")
+	@PostMapping("/logout")
 	@Operation(summary = "로그아웃", description = "로그아웃 처리")
 	public ResponseEntity<String> logout(@AuthenticationPrincipal Member member){
 		memberService.logout(member);

--- a/src/main/java/motgolla/domain/member/dto/request/LoginRequest.java
+++ b/src/main/java/motgolla/domain/member/dto/request/LoginRequest.java
@@ -7,6 +7,9 @@ public record LoginRequest(
     String idToken,
 
     @Schema(description = "소셜 로그인에서 받은 고유 식별자", example = "kakao_123456")
-    String oauthId
+    String oauthId,
+
+    @Schema(description = "재로그인 여부(6개월 이내 탈퇴 회원) 기본값 false", example = "false")
+    boolean reSignUp
 ) {
 }

--- a/src/main/java/motgolla/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/motgolla/domain/member/mapper/MemberMapper.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.springframework.security.core.parameters.P;
 
 import motgolla.domain.member.dto.request.SignUpRequest;
 import motgolla.domain.member.vo.Member;
@@ -14,4 +15,5 @@ public interface MemberMapper {
 	void updateIsDeleted(Long id);
 	Optional<Member> findById(Long id);
 	Optional<Member> findByOauthId(String oauthId);
+	void updateIsDeletedFalse(@Param("oauthId") String oauthId);
 }

--- a/src/main/java/motgolla/global/config/SecurityConfig.java
+++ b/src/main/java/motgolla/global/config/SecurityConfig.java
@@ -104,7 +104,7 @@ public class SecurityConfig {
     @Bean
     public CustomJsonUsernamePasswordAuthenticationFilter customJsonUsernamePasswordAuthenticationFilter() {
         CustomJsonUsernamePasswordAuthenticationFilter customJsonUsernamePasswordLoginFilter
-                = new CustomJsonUsernamePasswordAuthenticationFilter(objectMapper);
+                = new CustomJsonUsernamePasswordAuthenticationFilter(objectMapper, memberMapper);
         customJsonUsernamePasswordLoginFilter.setAuthenticationManager(authenticationManager());
         customJsonUsernamePasswordLoginFilter.setAuthenticationFailureHandler(loginFailureHandler());
         customJsonUsernamePasswordLoginFilter.setAuthenticationSuccessHandler(loginSuccessHandler());

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -78,4 +78,11 @@
         SET IS_DELETED = 1, UPDATED_AT = SYSDATE, UPDATED_BY = #{id}
         WHERE ID = #{id}
     </update>
+
+    <!-- 회원 재가입 -->
+    <update id="updateIsDeletedFalse">
+        UPDATE MEMBER
+        SET IS_DELETED = 0, UPDATED_AT = SYSDATE
+        WHERE IS_DELETED = 1 AND OAUTH_ID = #{oauthId}
+    </update>
 </mapper>


### PR DESCRIPTION
## #️⃣ Issue Number

#6 

## 📝 요약(Summary)

1. 재가입 요청 추가
2. logout http 메서드 수정

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

1. 재가입 요청 추가
- 6개월 이내 탈퇴 이력이 있는 회원은 로그인 시도 시 `RECENT_RESIGNED_MEMBER` 에러 반환
- `LoginRequest`에 `reSignUp = true`로 요청 시 재 로그인 처리(필터)

2. logout http 메서드 수정
- GET -> POST로 수정

