### PR TITLE
fix: 기록 상세 조회 시 상품 아이디 조회 추가

### DIFF
--- a/src/main/java/motgolla/domain/record/api/RecordController.java
+++ b/src/main/java/motgolla/domain/record/api/RecordController.java
@@ -89,7 +89,7 @@ public class RecordController {
   @GetMapping("/{recordId}")
   public RecordDetailResponse getRecordDetail(
       @Parameter(description = "조회할 Record의 ID", example = "1")
-      @PathVariable Long recordId) {
+      @PathVariable("recordId") Long recordId) {
     return recordService.getRecordDetail(recordId);
   }
 

--- a/src/main/java/motgolla/domain/record/dto/response/RecordDetailResponse.java
+++ b/src/main/java/motgolla/domain/record/dto/response/RecordDetailResponse.java
@@ -13,6 +13,9 @@ public class RecordDetailResponse {
     @Schema(description = "Record ID", example = "1")
     private Long recordId;
 
+    @Schema(description = "Product ID", example = "1")
+    private Long productId;
+
     @Schema(description = "상품 이름", example = "파인 메리노 울 4-바 클래식 카디건")
     private String productName;
 

--- a/src/main/resources/mapper/RecordMapper.xml
+++ b/src/main/resources/mapper/RecordMapper.xml
@@ -120,6 +120,7 @@
   <select id="findRecordMainById" resultType="motgolla.domain.record.dto.response.RecordDetailResponse">
     SELECT
     r.ID AS recordId,
+    r.PRODUCT_ID AS productId,
     p.NAME AS productName,
     b.BRAND_NAME AS brandName,
     p.PRICE AS productPrice,


### PR DESCRIPTION
## #️⃣ Issue Number

#27 

## 📝 요약(Summary)

기록 상세 조회 후 추천 상품 목록 조회를 위해
기록 상세 조회 API 응답에 상품 아이디 정보 추가 
